### PR TITLE
TypeError in module_0/feature_repo_gcp/features.py

### DIFF
--- a/module_0/feature_repo_gcp/features.py
+++ b/module_0/feature_repo_gcp/features.py
@@ -12,7 +12,7 @@ from entities import *
 driver_hourly_stats_view = FeatureView(
     name="driver_hourly_stats",
     description="Hourly features",
-    entities=["driver"],
+    entities=[driver],
     ttl=timedelta(seconds=8640000000),
     schema=[
         Field(name="conv_rate", dtype=Float32),


### PR DESCRIPTION
There seems to be a simple typo causing following error: 
```
TypeError: type of argument "entities" must be one of (List[feast.entity.Entity], NoneType); got list instead
```